### PR TITLE
update syllable position logic

### DIFF
--- a/src/syllable.ts
+++ b/src/syllable.ts
@@ -38,7 +38,6 @@ export class Syllable extends Node<Syllable, Cluster, Word> {
   #clusters: Cluster[];
   #isClosed: boolean;
   #isAccented: boolean;
-  #isFinal: boolean;
   #vowelsCache: SyllableVowel[] | null = null;
   #vowelNamesCache: SyllableVowelName[] | null = null;
 
@@ -57,13 +56,12 @@ export class Syllable extends Node<Syllable, Cluster, Word> {
    * See the [Syllabification](/guides/syllabification) page for how a syllable is determined.
    * Currently, the Divine Name (e.g. יהוה), non-Hebrew text, and Hebrew punctuation (e.g. _passeq_, _nun hafucha_) are treated as a _single syllable_ because these do not follow the rules of Hebrew syllabification.
    */
-  constructor(clusters: Cluster[], { isClosed = false, isAccented = false, isFinal = false }: SyllableParams = {}) {
+  constructor(clusters: Cluster[], { isClosed = false, isAccented = false }: SyllableParams = {}) {
     super();
     this.value = this;
     this.#clusters = clusters;
     this.#isClosed = isClosed;
     this.#isAccented = isAccented;
-    this.#isFinal = isFinal;
   }
 
   #isCharKeyOfSyllableVowelCharToNameMap(char: string): char is keyof SyllableVowelCharToNameMap {
@@ -332,33 +330,6 @@ export class Syllable extends Node<Syllable, Cluster, Word> {
   }
 
   /**
-   * Checks if the Syllable is the final syllable in a {@link Word}
-   *
-   * @returns true if Syllable is final
-   *
-   * @example
-   * ```ts
-   * const text = new Text("וַיִּקְרָ֨א");
-   * text.syllables[0].isFinal; // i.e. "וַ"
-   * // false
-   * text.syllables[2].isFinal; // i.e. "רָ֨א"
-   * // true
-   * ```
-   */
-  get isFinal() {
-    return this.#isFinal;
-  }
-
-  /**
-   * Sets whether the Syllable is the final syllable in a {@link Word}
-   *
-   * @param final a boolean for whether the Syllable is the final Syallble
-   */
-  set isFinal(final: boolean) {
-    this.#isFinal = final;
-  }
-
-  /**
    * Returns the nucleus of the syllable - see {@link structure}
    *
    * @returns the nucleus of the syllable as a string, including any taamim - see {@link structure}
@@ -454,7 +425,7 @@ export class Syllable extends Node<Syllable, Cluster, Word> {
     // Furtive patah: If the syllable is final and is either a het, ayin, or he
     // (with dagesh) followed by a patah, then it has no onset, its nucleus is
     // the patah and its coda is the consonant
-    if (this.isFinal && !this.isClosed) {
+    if (this.word?.isSyllableFinal(this) && !this.isClosed) {
       const matchFurtive = this.text.match(/(\u{05D7}|\u{05E2}|\u{05D4}\u{05BC})(\u{05B7})(\u{05C3})?$/mu);
       if (matchFurtive) {
         const structure: [string, string, string] = ["", matchFurtive[2], matchFurtive[1] + (matchFurtive[3] || "")];

--- a/src/utils/syllabifier.ts
+++ b/src/utils/syllabifier.ts
@@ -418,7 +418,7 @@ const setIsAccented = (syllable: Syllable) => {
   const segolta = /\u{0592}/u;
   if (segolta.test(syllable.text)) {
     // see לָֽאָדָם֒ as an example of segolta on the final syllable
-    if (syllable.isFinal && prev) {
+    if (!syllable.next && prev) {
       // see יֹאשִׁיָּ֒הוּ֒ as an example of segolta on a previous syllable
       while (prev) {
         if (segolta.test(prev.text)) {
@@ -443,7 +443,7 @@ const setIsAccented = (syllable: Syllable) => {
     const zarqaHelper = /\u{0598}/u;
     // see לָֽאָדָם֒ as an example of zarqa on the final syllable
     // a zarqa should always be on the final syllable
-    if (syllable.isFinal && prev) {
+    if (!syllable.next && prev) {
       // see וַיֹּ֘אמֶר֮ as an example of zarqa helper on a previous syllable
       while (prev) {
         if (zarqaHelper.test(prev.text)) {
@@ -468,7 +468,7 @@ const setIsAccented = (syllable: Syllable) => {
   // check if any preceding syllable has a pashta or qadma character
   const pashta = /\u{0599}/u;
   const sylText = syllable.text;
-  if (syllable.isFinal && pashta.test(sylText)) {
+  if (!syllable.next && pashta.test(sylText)) {
     const qadma = /\u{05A8}/u;
     while (prev) {
       if (pashta.test(prev.text) || qadma.test(prev.text)) {
@@ -583,8 +583,7 @@ const reinsertLatin = (syls: Syllable[], latin: { cluster: Cluster; pos: number 
       const firstSyl = syls[0];
       syls[0] = new Syllable([...partial, ...firstSyl.clusters], {
         isAccented: firstSyl.isAccented,
-        isClosed: firstSyl.isClosed,
-        isFinal: firstSyl.isFinal
+        isClosed: firstSyl.isClosed
       });
     } else {
       const lastSyl = syls[numOfSyls - 1];
@@ -594,8 +593,7 @@ const reinsertLatin = (syls: Syllable[], latin: { cluster: Cluster; pos: number 
       }
       syls[numOfSyls - 1] = new Syllable([...lastSyl.clusters, ...partial], {
         isAccented: lastSyl.isAccented,
-        isClosed: lastSyl.isClosed,
-        isFinal: lastSyl.isFinal
+        isClosed: lastSyl.isClosed
       });
     }
   }
@@ -613,7 +611,6 @@ export const syllabify = (clusters: Cluster[], options: SylOpts, isWordInConstru
   first.siblings = rest;
 
   // set syllable properties
-  syllables[syllables.length - 1].isFinal = true;
   syllables.forEach(setIsClosed);
   syllables.forEach(setIsAccented);
 

--- a/src/word.ts
+++ b/src/word.ts
@@ -76,6 +76,7 @@ export class Word extends Node<Word, Text> {
    */
   whiteSpaceAfter: string | null;
   #sylOpts: SylOpts;
+  #syllablesCache: Syllable[] | null = null;
 
   constructor(text: string, sylOpts: SylOpts, original?: string) {
     super();
@@ -340,6 +341,28 @@ export class Word extends Node<Word, Text> {
   }
 
   /**
+   * Checks if the syllable is the final syllable in the Word
+   *
+   * @param syllable
+   * @returns a boolean indicating if the syllable is the final syllable in the Word
+   */
+  isSyllableFinal(syllable: Syllable) {
+    const index = this.syllablePosition(syllable);
+    return index === this.syllables.length - 1;
+  }
+
+  /**
+   * Checks if the syllable is the initial syllable in the Word
+   *
+   * @param syllable
+   * @returns a boolean indicating if the syllable is the initial syllable in the Word
+   */
+  isSyllableInitial(syllable: Syllable) {
+    const index = this.syllablePosition(syllable);
+    return index === 0;
+  }
+
+  /**
    * The original string passed
    *
    * @returns the original string passed
@@ -367,16 +390,36 @@ export class Word extends Node<Word, Text> {
    * ```
    */
   get syllables() {
+    if (this.#syllablesCache) {
+      return this.#syllablesCache;
+    }
+
     if (/\w/.test(this.text) || this.isDivineName || this.isNotHebrew) {
       const syl = new Syllable(this.clusters);
       syl.parent = this;
+      this.#syllablesCache = [syl];
       return [syl];
     }
 
     const syllables = syllabify(this.clusters, this.#sylOpts, this.isInConstruct);
     syllables.forEach((syl) => (syl.parent = this));
 
+    this.#syllablesCache = syllables;
     return syllables;
+  }
+
+  /**
+   * Gets the position of a syllable within the Word
+   *
+   * @param syllable
+   * @returns the position of the syllable within the Word (0-based index)
+   */
+  syllablePosition(syllable: Syllable) {
+    const index = this.syllables.findIndex((syl) => syl === syllable);
+    if (index === -1) {
+      throw new Error("Syllable not found in word");
+    }
+    return index;
   }
 
   /**

--- a/test/word.test.ts
+++ b/test/word.test.ts
@@ -141,6 +141,50 @@ describe.each`
 });
 
 describe.each`
+  description               | hebrew        | syllableNum | isFinal  | isInitial
+  ${"initial syllable"}     | ${"הָאָ֖רֶץ"} | ${0}        | ${false} | ${true}
+  ${"middle syllable"}      | ${"הָאָ֖רֶץ"} | ${1}        | ${false} | ${false}
+  ${"final syllable"}       | ${"הָאָ֖רֶץ"} | ${2}        | ${true}  | ${false}
+  ${"single syllable word"} | ${"יָם"}      | ${0}        | ${true}  | ${true}
+`("isSyllableFinal/isSyllableInitial:", ({ description, hebrew, syllableNum, isFinal, isInitial }) => {
+  const text = new Text(hebrew);
+  const word = text.words[0];
+  const syllable = word.syllables[syllableNum];
+  describe(description, () => {
+    test(`isSyllableFinal to equal ${isFinal}`, () => {
+      expect(word.isSyllableFinal(syllable)).toEqual(isFinal);
+    });
+    test(`isSyllableInitial to equal ${isInitial}`, () => {
+      expect(word.isSyllableInitial(syllable)).toEqual(isInitial);
+    });
+  });
+});
+
+describe.each`
+  description          | hebrew        | syllableNum | expectedPosition
+  ${"first syllable"}  | ${"הָאָ֖רֶץ"} | ${0}        | ${0}
+  ${"middle syllable"} | ${"הָאָ֖רֶץ"} | ${1}        | ${1}
+  ${"last syllable"}   | ${"הָאָ֖רֶץ"} | ${2}        | ${2}
+`("syllablePosition:", ({ description, hebrew, syllableNum, expectedPosition }) => {
+  const text = new Text(hebrew);
+  const word = text.words[0];
+  const syllable = word.syllables[syllableNum];
+  describe(description, () => {
+    test(`position to equal ${expectedPosition}`, () => {
+      expect(word.syllablePosition(syllable)).toEqual(expectedPosition);
+    });
+  });
+});
+
+describe("syllablePosition (error)", () => {
+  test("throws error for syllable not in word", () => {
+    const text1 = new Text("הָאָ֖רֶץ");
+    const text2 = new Text("מָחֳר");
+    expect(() => text1.words[0].syllablePosition(text2.syllables[0])).toThrow("Syllable not found in word");
+  });
+});
+
+describe.each`
   description              | hebrew              | taamim
   ${"one character"}       | ${"הָאָ֖רֶץ"}       | ${["\u{596}"]}
   ${"no characters"}       | ${"וַֽיְהִי־כֵֽן׃"} | ${[]}


### PR DESCRIPTION
Closes #224 by updating how `Syllable` position logic is handled.

- removed `Syllable.isFinal` prop
- added:
  - `Word.syllablePosition(syllable: Syllable)`
  - `Word.isSyllableFina(syllable: Syllable)`
  - `Word.isSyllableInitial(syllable: Syllable)`

Breaking change